### PR TITLE
Correct spelling February

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -49,7 +49,7 @@ def plural(i):
 
 months = {
     'january': 1,
-    'febuary': 2,
+    'february': 2,
     'march': 3,
     'april': 4,
     'may': 5,


### PR DESCRIPTION
Failing with a KeyError if a message has a month in February due to it being misspelled in the dict. See code.
